### PR TITLE
Avoid unintended use of toString-based sort; closes #3.

### DIFF
--- a/diff.js
+++ b/diff.js
@@ -294,7 +294,7 @@ var diff = {
     }
     for (i = 0; i < m1.length; i++) { addHunk(m1[i], 0); }
     for (i = 0; i < m2.length; i++) { addHunk(m2[i], 2); }
-    hunks.sort();
+    hunks.sort(function (x, y) { return x[0] - y[0] });
 
     var result = [];
     var commonOffset = 0;


### PR DESCRIPTION
Fix taken from https://github.com/tonyg/synchrotron/commit/7eb715d08d3c7b479b30b9f413a4a61db9940e82.
